### PR TITLE
Create and pass tests for user story 14

### DIFF
--- a/app/views/admins/show.html.erb
+++ b/app/views/admins/show.html.erb
@@ -12,6 +12,7 @@ Pets:
     <li id="<%= index %>"><%= "#{pet.name}" %>
     <% if pet.app_status(@application.id).nil? %>
       <%= button_to "Approve", "/application_pets/#{pet.app_join_id(@application.id)}", method: :patch, local: :true, params: {status: 'Approved'} %>
+      <%= button_to "Reject", "/application_pets/#{pet.app_join_id(@application.id)}", method: :patch, local: :true, params: {status: 'Rejected'} %>
     <% else %>
       <%= pet.app_status(@application.id) %>
     <% end %>

--- a/spec/features/admins/show_spec.rb
+++ b/spec/features/admins/show_spec.rb
@@ -35,4 +35,26 @@ RSpec.describe 'the admin application show page' do
       expect(page).to have_content('Approved')
     end
   end
+  describe 'rejecting a et' do
+    it 'should have reject buttons next to each pet' do
+
+      visit "/admin/applications/#{@application.id}"
+
+
+      expect(page).to have_button('Reject', count: 2)
+    end
+
+    it 'should remove the reject button and show Approved when clicked' do
+      visit "/admin/applications/#{@application.id}"
+
+      expect(page).to_not have_content('Approved')
+
+      within('li#0') do
+        click_button('Reject')
+      end
+
+      expect(page).to have_button('Reject')
+      expect(page).to have_content('Rejected')
+    end
+  end
 end


### PR DESCRIPTION
As a visitor
When I visit an admin application show page ('/admin/applications/:id')
For every pet that the application is for, I see a button to reject the application for that specific pet
When I click that button
Then I'm taken back to the admin application show page
And next to the pet that I rejected, I do not see a button to approve or reject this pet
And instead I see an indicator next to the pet that they have been rejected